### PR TITLE
Handle offsetParent being null on offset calculation

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -539,13 +539,13 @@ export default {
       this.updatePaneStyle();
     },
     getElOffset(el) {
-      let offsetParent = el;
       let top = el.offsetTop;
       let left = el.offsetLeft;
-      while (offsetParent != document.body) {
-        offsetParent = offsetParent.offsetParent;
+      let offsetParent = el.offsetParent;
+      while (offsetParent && offsetParent != document.body) {
         top += offsetParent.offsetTop;
         left += offsetParent.offsetLeft;
+        offsetParent = offsetParent.offsetParent;
       }
       return {
         top,


### PR DESCRIPTION
There are a few situations where `$el.offsetParent` will return a `null`:

1. Parent having `display: none`
2. Parent having `position: fixed` (at least on Chrome)
3. document hasn't finished loading yet

I am experiencing item two and this is my proposed fix. I've tested the PR locally with an application that heavily uses this component.

And thanks by the way 🙏