### PR TITLE
Fixing the days of the week being wrong when the first day of the month is a monday

### DIFF
--- a/src/components/Calendar.vue
+++ b/src/components/Calendar.vue
@@ -774,7 +774,7 @@ export default {
         const currMonthFirstDay = new Date(time.year, time.month, 1);
         let firstDayWeek = this.prefixLen(currMonthFirstDay);
         const dayCount = this.getDayCount(time.year, time.month);
-        if (firstDayWeek > 1) {
+        if (firstDayWeek >= 1) {
           const preMonth = this.getYearMonth(time.year, time.month - 1);
           const prevMonthDayCount = this.getDayCount(
             preMonth.year,


### PR DESCRIPTION
The calendar is broken when the first day of the month is a Sunday. April 2019 is a good example of this. vue-calendar currently shows it as a Sunday, when it is, in fact, a Monday, but it is being displayed as a Sunday, throwing off all the dates for that month. 